### PR TITLE
Consolidate HWFinder

### DIFF
--- a/src/HwFinder.php
+++ b/src/HwFinder.php
@@ -39,12 +39,22 @@ final class HwFinder implements CpuCoreFinder
 
         if (is_resource($process)) {
             // *nix (Linux, BSD and Mac)
-            $cores = (int) fgets($process);
+            $cores = self::countCpuCores(fgets($process));
             pclose($process);
 
             return $cores;
         }
 
         return null;
+    }
+
+    /**
+     * @internal
+     *
+     * @return positive-int|null
+     */
+    public static function countCpuCores(string $process): ?int
+    {
+        return (int) $process;
     }
 }

--- a/tests/HwFinderTest.php
+++ b/tests/HwFinderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCounter\Test;
+
+use Fidry\CpuCounter\HwFinder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Fidry\CpuCounter\HwFinder
+ *
+ * @internal
+ */
+final class HwFinderTest extends TestCase
+{
+    /**
+     * @dataProvider processProvider
+     */
+    public function test_it_can_count_the_number_of_cpu_cores(
+        string $process,
+        ?int $expected
+    ): void {
+        $actual = HwFinder::countCpuCores($process);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function processProvider(): iterable
+    {
+        // MyMachine™
+        yield 'example from an OSX machine' => [
+            <<<'EOF'
+                3
+
+                EOF,
+            3,
+        ];
+    }
+}


### PR DESCRIPTION
Split the "get the string which contains the info" and the "retrieve the info from the string" in order to add unit tests to the 2nd one.