### PR TITLE
Allow the user to register which finders to use to the CPUCoreCounter

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -18,7 +18,20 @@ use const DIRECTORY_SEPARATOR;
 
 final class CpuCoreCounter
 {
+    /**
+     * @var list<CpuCoreFinder>
+     */
+    private array $finders;
+
     private int $count;
+
+    /**
+     * @param list<CpuCoreFinder> $finders
+     */
+    public function __construct(?array $finders = null)
+    {
+        $this->finders = $finders ?? self::getDefaultFinders();
+    }
 
     /**
      * @return positive-int
@@ -27,7 +40,7 @@ final class CpuCoreCounter
     {
         // Memoize result
         if (!isset($this->count)) {
-            $this->count = self::findCount();
+            $this->count = $this->findCount();
         }
 
         return $this->count;
@@ -36,25 +49,14 @@ final class CpuCoreCounter
     /**
      * @return positive-int
      */
-    private static function findCount(): int
+    private function findCount(): int
     {
         if (!function_exists('proc_open')) {
             return 1;
         }
 
-        /** @var list<class-string<CpuCoreFinder>> $finders */
-        $finders = [
-            CpuInfoFinder::class,
-        ];
-
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $finders[] = WindowsWmicFinder::class;
-        }
-
-        $finders[] = HwFinder::class;
-
-        foreach ($finders as $finder) {
-            $cores = $finder::find();
+        foreach ($this->finders as $finder) {
+            $cores = $finder->find();
 
             if (null !== $cores) {
                 return $cores;
@@ -62,5 +64,24 @@ final class CpuCoreCounter
         }
 
         return 2;
+    }
+
+    /**
+     * @return list<CpuCoreFinder>
+     */
+    private static function getDefaultFinders(): array
+    {
+        /** @var list<class-string<CpuCoreFinder>> $finders */
+        $finders = [
+            new CpuInfoFinder(),
+        ];
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $finders[] = new WindowsWmicFinder();
+        }
+
+        $finders[] = new HwFinder();
+
+        return $finders;
     }
 }

--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -69,7 +69,7 @@ final class CpuCoreCounter
     /**
      * @return list<CpuCoreFinder>
      */
-    private static function getDefaultFinders(): array
+    public static function getDefaultFinders(): array
     {
         /** @var list<class-string<CpuCoreFinder>> $finders */
         $finders = [

--- a/src/CpuCoreFinder.php
+++ b/src/CpuCoreFinder.php
@@ -18,5 +18,5 @@ interface CpuCoreFinder
     /**
      * @return positive-int|null
      */
-    public static function find(): ?int;
+    public function find(): ?int;
 }

--- a/src/CpuInfoFinder.php
+++ b/src/CpuInfoFinder.php
@@ -28,10 +28,6 @@ final class CpuInfoFinder
 {
     private const CPU_INFO_PATH = '/proc/cpuinfo';
 
-    private function __construct()
-    {
-    }
-
     /**
      * @return positive-int|null
      */

--- a/src/HwFinder.php
+++ b/src/HwFinder.php
@@ -26,14 +26,10 @@ use function popen;
  */
 final class HwFinder implements CpuCoreFinder
 {
-    private function __construct()
-    {
-    }
-
     /**
      * @return positive-int|null
      */
-    public static function find(): ?int
+    public function find(): ?int
     {
         $process = popen('sysctl -n hw.ncpu', 'rb');
 

--- a/src/WindowsWmicFinder.php
+++ b/src/WindowsWmicFinder.php
@@ -25,14 +25,10 @@ use function popen;
  */
 final class WindowsWmicFinder implements CpuCoreFinder
 {
-    private function __construct()
-    {
-    }
-
     /**
      * @return positive-int|null
      */
-    public static function find(): ?int
+    public function find(): ?int
     {
         // Windows
         $process = popen('wmic cpu get NumberOfLogicalProcessors', 'rb');

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -29,4 +29,61 @@ final class CpuCoreCounterTest extends TestCase
 
         self::assertGreaterThan(1, $counter->getCount());
     }
+
+    /**
+     * @dataProvider cpuCoreFinderProvider
+     *
+     * @param list<CpuCoreCounter> $finders
+     */
+    public function test_it_can_get_the_number_of_cpu_cores_based_on_the_registered_finders(
+        array $finders,
+        int $expected
+    ): void {
+        $counter = new CpuCoreCounter($finders);
+
+        $actual = $counter->getCount();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function cpuCoreFinderProvider(): iterable
+    {
+        yield 'no finder' => [
+            [],
+            2,
+        ];
+
+        yield 'single finder finds a value' => [
+            [
+                new DummyCpuCoreFinder(3),
+            ],
+            3,
+        ];
+
+        yield 'single finder does not find a value' => [
+            [
+                new DummyCpuCoreFinder(null),
+            ],
+            2,
+        ];
+
+        yield 'multiple finders find a value' => [
+            [
+                new DummyCpuCoreFinder(3),
+                new DummyCpuCoreFinder(7),
+                new DummyCpuCoreFinder(11),
+            ],
+            3,
+        ];
+
+        yield 'multiple finders find a value with some not finding any' => [
+            [
+                new DummyCpuCoreFinder(null),
+                new DummyCpuCoreFinder(7),
+                new DummyCpuCoreFinder(null),
+                new DummyCpuCoreFinder(11),
+            ],
+            7,
+        ];
+    }
 }

--- a/tests/DummyCpuCoreFinder.php
+++ b/tests/DummyCpuCoreFinder.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCounter\Test;
+
+use Fidry\CpuCounter\CpuCoreFinder;
+
+final class DummyCpuCoreFinder implements CpuCoreFinder
+{
+    private ?int $count;
+
+    public function __construct(?int $count)
+    {
+        $this->count = $count;
+    }
+
+    public function find(): ?int
+    {
+        return $this->count;
+    }
+}


### PR DESCRIPTION
For BC and convenience, the `CPUCoreCounter` can still be created without any finder which will use the default registered ones.

This feature will allow users to blacklist some finders, for example for Psalm which does not want to use the `WindowsWmicFinder`:

```php
$finders = array_filter(
    CpuCoreCounter::getDefaultFinders(),
    static fn (CpuCoreFinder $finder) => !($finder instanceof WindowsWmicFinder)
);

$cores = (new CpuCoreCounter($finders))->getCount();
```

Another bonus is that it helps out a lot for testing!