### PR TITLE
Throw exception upon failure instead of arbitrary default value

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -26,7 +26,7 @@ final class CpuCoreCounter
     private int $count;
 
     /**
-     * @param list<CpuCoreFinder> $finders
+     * @param list<CpuCoreFinder>|null $finders
      */
     public function __construct(?array $finders = null)
     {

--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -21,6 +21,8 @@ final class CpuCoreCounter
     private int $count;
 
     /**
+     * @throws NumberOfCpuCoreNotFound
+     *
      * @return positive-int
      */
     public function getCount(): int
@@ -34,6 +36,8 @@ final class CpuCoreCounter
     }
 
     /**
+     * @throws NumberOfCpuCoreNotFound
+     *
      * @return positive-int
      */
     private static function findCount(): int
@@ -61,6 +65,6 @@ final class CpuCoreCounter
             }
         }
 
-        return 2;
+        throw NumberOfCpuCoreNotFound::create();
     }
 }

--- a/src/NumberOfCpuCoreNotFound.php
+++ b/src/NumberOfCpuCoreNotFound.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCounter;
+
+use RuntimeException;
+
+final class NumberOfCpuCoreNotFound extends RuntimeException
+{
+    public static function create(): self
+    {
+        return new self(
+            'Could not find the number of CPU cores available.',
+        );
+    }
+}

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @internal
  */
-final class CpuCounterTest extends TestCase
+final class CpuCoreCounterTest extends TestCase
 {
     public function test_it_can_get_the_number_of_cpu_cores(): void
     {


### PR DESCRIPTION
The reasoning is that depending of the context, one may want to apply a different arbitrary default value. It is easier to do that by wrapping the call in a try/catch catching a specific exception rather than getting the value directly (since you wouldn't know if you get the right value found, or the default one).