### PR TITLE
Consolidate WindowsWmicFinder

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Fidry\CpuCounter;
 
 use function function_exists;
-use const DIRECTORY_SEPARATOR;
 
 final class CpuCoreCounter
 {
@@ -76,16 +75,10 @@ final class CpuCoreCounter
     public static function getDefaultFinders(): array
     {
         /** @var list<class-string<CpuCoreFinder>> $finders */
-        $finders = [
+        return [
             new CpuInfoFinder(),
+            new WindowsWmicFinder(),
+            new HwFinder(),
         ];
-
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $finders[] = new WindowsWmicFinder();
-        }
-
-        $finders[] = new HwFinder();
-
-        return $finders;
     }
 }

--- a/src/WindowsWmicFinder.php
+++ b/src/WindowsWmicFinder.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCounter;
 
+use function defined;
 use function fgets;
 use function filter_var;
+use function function_exists;
 use function is_int;
 use function is_resource;
 use function pclose;
@@ -34,18 +36,25 @@ final class WindowsWmicFinder implements CpuCoreFinder
      */
     public function find(): ?int
     {
-        // Windows
-        $process = popen('wmic cpu get NumberOfLogicalProcessors', 'rb');
-
-        if (is_resource($process)) {
-            fgets($process);
-            $cores = self::countCpuCores(fgets($process));
-            pclose($process);
-
-            return $cores;
+        if (!function_exists('popen')
+            || !defined('PHP_WINDOWS_VERSION_MAJOR')
+        ) {
+            return null;
         }
 
-        return null;
+        // -n to show only the variable value
+        $process = popen('wmic cpu get NumberOfLogicalProcessors', 'rb');
+
+        if (!is_resource($process)) {
+            return null;
+        }
+
+        $processResult = fgets($process);
+        pclose($process);
+
+        return false === $processResult
+            ? null
+            : self::countCpuCores($processResult);
     }
 
     /**


### PR DESCRIPTION
- Move the `popen` function check instead of relying on the `CpuCoreCounter`'s `proc_open` check.
- Return `null` directly if is not on Windows (hence the command will not work); this was previously done in `CpuCoreCounter` but it more belongs to the finder as it's really a micro-optimization since the constant defined check is faster than doing `popen`
- Refactor `WindowsWmicFinder::find()` for better readability
- Handle potential `fgets` `false` value returned
