### PR TITLE
Re-order the default finders

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -76,9 +76,10 @@ final class CpuCoreCounter
     {
         /** @var list<class-string<CpuCoreFinder>> $finders */
         return [
-            new CpuInfoFinder(),
+            new NProcFinder(),
             new WindowsWmicFinder(),
             new HwFinder(),
+            new CpuInfoFinder(),
         ];
     }
 }

--- a/src/NProcFinder.php
+++ b/src/NProcFinder.php
@@ -16,6 +16,7 @@ namespace Fidry\CpuCounter;
 use Fidry\CpuCounter\Exec\ExecException;
 use Fidry\CpuCounter\Exec\ShellExec;
 use function filter_var;
+use function function_exists;
 use function is_int;
 use function trim;
 use const FILTER_VALIDATE_INT;
@@ -31,6 +32,10 @@ final class NProcFinder implements CpuCoreFinder
      */
     public function find(): ?int
     {
+        if (!function_exists('shell_exec')) {
+            return null;
+        }
+
         if (!self::supportsNproc()) {
             return null;
         }

--- a/src/NProcFinder.php
+++ b/src/NProcFinder.php
@@ -24,16 +24,12 @@ use const FILTER_VALIDATE_INT;
  * @see https://github.com/infection/infection/blob/fbd8c44/src/Resource/Processor/CpuCoresCountProvider.php#L69-L82
  * @see https://unix.stackexchange.com/questions/146051/number-of-processors-in-proc-cpuinfo
  */
-final class NProcFinder
+final class NProcFinder implements CpuCoreFinder
 {
-    private function __construct()
-    {
-    }
-
     /**
      * @return positive-int|null
      */
-    public static function find(): ?int
+    public function find(): ?int
     {
         if (!self::supportsNproc()) {
             return null;


### PR DESCRIPTION
Re-order the default finders to a more sensible order:

- nproc is probably the most reliable way
- if on windows, wmic is probably the best way
- cpuinfo is the least good one, hence placed as last