### PR TITLE
Remove unnecessary proc_open check

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCounter;
 
-use function function_exists;
-
 final class CpuCoreCounter
 {
     /**
@@ -54,10 +52,6 @@ final class CpuCoreCounter
      */
     private function findCount(): int
     {
-        if (!function_exists('proc_open')) {
-            return 1;
-        }
-
         foreach ($this->finders as $finder) {
             $cores = $finder->find();
 


### PR DESCRIPTION
I am not entirely sure why `proc_open` itself was checked when unused (in any implementation). I however don't think it's relevant anymore:

- Each finder checks if the proc related functions do exist (I assume if `proc_open` was not there then `popen` was not neither).
- In case it was not available, it was returning `1`, whereas I think the `NumberOfCpuCoreNotFound` makes more sense.