### PR TITLE
Rename the CpuFinder namespace to CpuCoreFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ composer require fidry/cpu-core-counter
 ## Usage
 
 ```php
-use Fidry\CpuCounter\CpuCoreCounter;
+use Fidry\CpuCoreCounter\CpuCoreCounter;
 
 $counter = new CpuCoreCounter();
 
@@ -43,7 +43,7 @@ $cores = (new CpuCoreCounter($finders))->getCount();
 
 ```php
 // Use CPUInfo first & don't use Nproc
-use Fidry\CpuCounter\CpuInfoFinder;use Fidry\CpuCounter\HwFinder;use Fidry\CpuCounter\WindowsWmicFinder;$finders = [
+use Fidry\CpuCoreCounter\CpuInfoFinder;use Fidry\CpuCoreCounter\HwFinder;use Fidry\CpuCoreCounter\WindowsWmicFinder;$finders = [
     new CpuInfoFinder(),
     new WindowsWmicFinder(),
     new HwFinder(),

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Fidry\\CpuCounter\\": "src/"
+            "Fidry\\CpuCoreCounter\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Fidry\\CpuCounter\\Test\\": "tests/"
+            "Fidry\\CpuCoreCounter\\Test\\": "tests/"
         }
     },
     "config": {

--- a/infection.json
+++ b/infection.json
@@ -17,7 +17,7 @@
         "@default": true,
         "ArrayItemRemoval": {
             "ignore": [
-                "Fidry\\CpuCounter\\CpuCoreCounter::getDefaultFinders"
+                "Fidry\\CpuCoreCounter\\CpuCoreCounter::getDefaultFinders"
             ]
         },
         "PublicVisibility": false

--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
 final class CpuCoreCounter
 {

--- a/src/CpuCoreFinder.php
+++ b/src/CpuCoreFinder.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
 interface CpuCoreFinder
 {

--- a/src/CpuInfoFinder.php
+++ b/src/CpuInfoFinder.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
 use function file_get_contents;
 use function is_file;

--- a/src/Exec/ExecException.php
+++ b/src/Exec/ExecException.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Exec;
+namespace Fidry\CpuCoreCounter\Exec;
 
 use ErrorException;
 use function error_get_last;

--- a/src/Exec/ShellExec.php
+++ b/src/Exec/ShellExec.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Exec;
+namespace Fidry\CpuCoreCounter\Exec;
 
 use function error_clear_last;
 use function shell_exec;

--- a/src/HwFinder.php
+++ b/src/HwFinder.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
 use function fgets;
 use function filter_var;

--- a/src/NProcFinder.php
+++ b/src/NProcFinder.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
-use Fidry\CpuCounter\Exec\ExecException;
-use Fidry\CpuCounter\Exec\ShellExec;
+use Fidry\CpuCoreCounter\Exec\ExecException;
+use Fidry\CpuCoreCounter\Exec\ShellExec;
 use function filter_var;
 use function function_exists;
 use function is_int;

--- a/src/NumberOfCpuCoreNotFound.php
+++ b/src/NumberOfCpuCoreNotFound.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
 use RuntimeException;
 

--- a/src/WindowsWmicFinder.php
+++ b/src/WindowsWmicFinder.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter;
+namespace Fidry\CpuCoreCounter;
 
 use function defined;
 use function fgets;

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -11,18 +11,18 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
 use Exception;
-use Fidry\CpuCounter\CpuCoreCounter;
-use Fidry\CpuCounter\CpuCoreFinder;
-use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
+use Fidry\CpuCoreCounter\CpuCoreCounter;
+use Fidry\CpuCoreCounter\CpuCoreFinder;
+use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 use PHPUnit\Framework\TestCase;
 use function get_class;
 use function is_int;
 
 /**
- * @covers \Fidry\CpuCounter\CpuCoreCounter
+ * @covers \Fidry\CpuCoreCounter\CpuCoreCounter
  *
  * @internal
  */

--- a/tests/CpuInfoFinderTest.php
+++ b/tests/CpuInfoFinderTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
-use Fidry\CpuCounter\CpuInfoFinder;
+use Fidry\CpuCoreCounter\CpuInfoFinder;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Fidry\CpuCounter\CpuInfoFinder
+ * @covers \Fidry\CpuCoreCounter\CpuInfoFinder
  *
  * @internal
  */

--- a/tests/DummyCpuCoreFinder.php
+++ b/tests/DummyCpuCoreFinder.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
-use Fidry\CpuCounter\CpuCoreFinder;
+use Fidry\CpuCoreCounter\CpuCoreFinder;
 
 final class DummyCpuCoreFinder implements CpuCoreFinder
 {

--- a/tests/HwFinderTest.php
+++ b/tests/HwFinderTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
-use Fidry\CpuCounter\HwFinder;
+use Fidry\CpuCoreCounter\HwFinder;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Fidry\CpuCounter\HwFinder
+ * @covers \Fidry\CpuCoreCounter\HwFinder
  *
  * @internal
  */

--- a/tests/MakefileTest.php
+++ b/tests/MakefileTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
 use Fidry\Makefile\Test\BaseMakefileTestCase;
 

--- a/tests/NProcFinderTest.php
+++ b/tests/NProcFinderTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
-use Fidry\CpuCounter\NProcFinder;
+use Fidry\CpuCoreCounter\NProcFinder;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Fidry\CpuCounter\NProcFinder
+ * @covers \Fidry\CpuCoreCounter\NProcFinder
  *
  * @internal
  */

--- a/tests/WindowsWmicTest.php
+++ b/tests/WindowsWmicTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\CpuCounter\Test;
+namespace Fidry\CpuCoreCounter\Test;
 
-use Fidry\CpuCounter\WindowsWmicFinder;
+use Fidry\CpuCoreCounter\WindowsWmicFinder;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Fidry\CpuCounter\WindowsWmicFinder
+ * @covers \Fidry\CpuCoreCounter\WindowsWmicFinder
  *
  * @internal
  */


### PR DESCRIPTION
Closes #35