### PR TITLE
Add `CpuCoreCounter::getFinderAndCores()`

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -73,6 +73,24 @@ final class CpuCoreCounter
     }
 
     /**
+     * @throws NumberOfCpuCoreNotFound
+     *
+     * @return array{CpuCoreFinder, positive-int}
+     */
+    public function getFinderAndCores(): array
+    {
+        foreach ($this->finders as $finder) {
+            $cores = $finder->find();
+
+            if (null !== $cores) {
+                return [$finder, $cores];
+            }
+        }
+
+        throw NumberOfCpuCoreNotFound::create();
+    }
+
+    /**
      * @return list<CpuCoreFinder>
      */
     public static function getDefaultFinders(): array


### PR DESCRIPTION
This allows to get information about the finder that returned the count. This should help tremendously with testing.