### PR TITLE
Change PopenBased finders to ProcOpenBased finders

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -20,6 +20,12 @@
                 "Fidry\\CpuCoreCounter\\CpuCoreCounter::getDefaultFinders"
             ]
         },
+        "CastString": {
+            "ignore": [
+                // I can't find a case in practice where this would happen
+                "Fidry\\CpuCoreCounter\\Exec\\ProcOpen::execute"
+            ]
+        },
         "FalseValue": {
             "ignore": [
                 // This is from thecodingmachine/safe – leave it alone
@@ -28,6 +34,8 @@
         },
         "FunctionCallRemoval": {
             "ignore": [
+                // I can't find a case in practice where this would happen
+                "Fidry\\CpuCoreCounter\\Exec\\ProcOpen::execute",
                 // This is from thecodingmachine/safe – leave it alone
                 "Fidry\\CpuCoreCounter\\Exec\\ShellExec::execute"
             ]

--- a/src/Exec/ProcOpen.php
+++ b/src/Exec/ProcOpen.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Exec;
+
+use function fclose;
+use function is_resource;
+use function proc_close;
+use function proc_open;
+use function stream_get_contents;
+
+final class ProcOpen
+{
+    /**
+     * @return array{string, string} STDOUT & STDERR tuple
+     */
+    public static function execute(string $command): ?array
+    {
+        $pipes = [];
+
+        $process = @proc_open(
+            $command,
+            [
+                ['pipe', 'rb'],
+                ['pipe', 'wb'], // stdout
+                ['pipe', 'wb'], // stderr
+            ],
+            $pipes
+        );
+
+        if (!is_resource($process)) {
+            return null;
+        }
+
+        fclose($pipes[0]);
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+
+        proc_close($process);
+
+        return [$stdout, $stderr];
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Finder/HwLogicalFinder.php
+++ b/src/Finder/HwLogicalFinder.php
@@ -19,7 +19,7 @@ namespace Fidry\CpuCoreCounter\Finder;
  * @see https://github.com/paratestphp/paratest/blob/c163539818fd96308ca8dc60f46088461e366ed4/src/Runners/PHPUnit/Options.php#L903-L909
  * @see https://opensource.apple.com/source/xnu/xnu-792.2.4/libkern/libkern/sysctl.h.auto.html
  */
-final class HwLogicalFinder extends PopenBasedFinder
+final class HwLogicalFinder extends ProcOpenBasedFinder
 {
     protected function getCommand(): string
     {

--- a/src/Finder/HwPhysicalFinder.php
+++ b/src/Finder/HwPhysicalFinder.php
@@ -19,7 +19,7 @@ namespace Fidry\CpuCoreCounter\Finder;
  * @see https://github.com/paratestphp/paratest/blob/c163539818fd96308ca8dc60f46088461e366ed4/src/Runners/PHPUnit/Options.php#L903-L909
  * @see https://opensource.apple.com/source/xnu/xnu-792.2.4/libkern/libkern/sysctl.h.auto.html
  */
-final class HwPhysicalFinder extends PopenBasedFinder
+final class HwPhysicalFinder extends ProcOpenBasedFinder
 {
     protected function getCommand(): string
     {

--- a/src/Finder/LinuxyNProcessorFinder.php
+++ b/src/Finder/LinuxyNProcessorFinder.php
@@ -18,7 +18,7 @@ namespace Fidry\CpuCoreCounter\Finder;
  *
  * @see https://twitter.com/freebsdfrau/status/1052016199452700678?s=20&t=M2pHkRqmmna-UF68lfL2hw
  */
-final class LinuxyNProcessorFinder extends PopenBasedFinder
+final class LinuxyNProcessorFinder extends ProcOpenBasedFinder
 {
     protected function getCommand(): string
     {

--- a/src/Finder/NProcessorFinder.php
+++ b/src/Finder/NProcessorFinder.php
@@ -18,7 +18,7 @@ namespace Fidry\CpuCoreCounter\Finder;
  *
  * @see https://twitter.com/freebsdfrau/status/1052016199452700678?s=20&t=M2pHkRqmmna-UF68lfL2hw
  */
-final class NProcessorFinder extends PopenBasedFinder
+final class NProcessorFinder extends ProcOpenBasedFinder
 {
     protected function getCommand(): string
     {

--- a/src/Finder/WindowsWmicLogicalFinder.php
+++ b/src/Finder/WindowsWmicLogicalFinder.php
@@ -20,7 +20,7 @@ use function defined;
  *
  * @see https://github.com/paratestphp/paratest/blob/c163539818fd96308ca8dc60f46088461e366ed4/src/Runners/PHPUnit/Options.php#L912-L916
  */
-final class WindowsWmicLogicalFinder extends PopenBasedFinder
+final class WindowsWmicLogicalFinder extends ProcOpenBasedFinder
 {
     /**
      * @return positive-int|null

--- a/src/Finder/WindowsWmicPhysicalFinder.php
+++ b/src/Finder/WindowsWmicPhysicalFinder.php
@@ -20,7 +20,7 @@ use function defined;
  *
  * @see https://github.com/paratestphp/paratest/blob/c163539818fd96308ca8dc60f46088461e366ed4/src/Runners/PHPUnit/Options.php#L912-L916
  */
-final class WindowsWmicPhysicalFinder extends PopenBasedFinder
+final class WindowsWmicPhysicalFinder extends ProcOpenBasedFinder
 {
     /**
      * @return positive-int|null

--- a/tests/Exec/ProcOpenTest.php
+++ b/tests/Exec/ProcOpenTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Test\Exec;
+
+use Fidry\CpuCoreCounter\Exec\ProcOpen;
+use PHPUnit\Framework\TestCase;
+use const PHP_EOL;
+
+/**
+ * @covers \Fidry\CpuCoreCounter\Exec\ProcOpen
+ *
+ * @internal
+ */
+final class ProcOpenTest extends TestCase
+{
+    public function test_it_can_execute_a_command_writing_output_to_the_stdout(): void
+    {
+        $command = 'echo "Hello world!"';
+
+        $expected = ['Hello world!'.PHP_EOL, ''];
+        $actual = ProcOpen::execute($command);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function test_it_can_execute_a_command_writing_output_to_the_stderr_instead_of_the_stdout(): void
+    {
+        $command = 'echo "Hello world!" 1>&2';
+
+        $expected = ['', 'Hello world!'.PHP_EOL];
+        $actual = ProcOpen::execute($command);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function test_it_can_execute_a_command_writing_output_to_the_stdout_instead_of_the_stderr(): void
+    {
+        $command = 'echoerr() { echo "$@" 1>&2; }; echoerr "Hello world!" 2>&1';
+
+        $expected = ['Hello world!'.PHP_EOL, ''];
+        $actual = ProcOpen::execute($command);
+
+        self::assertSame($expected, $actual);
+    }
+}

--- a/tests/Finder/DummyProcOpenBasedFinder.php
+++ b/tests/Finder/DummyProcOpenBasedFinder.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 
-final class DummyPopenBasedFinder extends PopenBasedFinder
+final class DummyProcOpenBasedFinder extends ProcOpenBasedFinder
 {
     protected function getCommand(): string
     {

--- a/tests/Finder/HwLogicalFinderTest.php
+++ b/tests/Finder/HwLogicalFinderTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
 use Fidry\CpuCoreCounter\Finder\HwLogicalFinder;
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 
 /**
  * @covers \Fidry\CpuCoreCounter\Finder\HwLogicalFinder
  *
  * @internal
  */
-final class HwLogicalFinderTest extends PopenBasedFinderTestCase
+final class HwLogicalFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
         self::assertSame('HwLogicalFinder', $this->getFinder()->toString());
     }
 
-    protected function getFinder(): PopenBasedFinder
+    protected function getFinder(): ProcOpenBasedFinder
     {
         return new HwLogicalFinder();
     }

--- a/tests/Finder/HwPhysicalFinderTest.php
+++ b/tests/Finder/HwPhysicalFinderTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
 use Fidry\CpuCoreCounter\Finder\HwPhysicalFinder;
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 
 /**
  * @covers \Fidry\CpuCoreCounter\Finder\HwPhysicalFinder
  *
  * @internal
  */
-final class HwPhysicalFinderTest extends PopenBasedFinderTestCase
+final class HwPhysicalFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
         self::assertSame('HwPhysicalFinder', $this->getFinder()->toString());
     }
 
-    protected function getFinder(): PopenBasedFinder
+    protected function getFinder(): ProcOpenBasedFinder
     {
         return new HwPhysicalFinder();
     }

--- a/tests/Finder/LinuxyNProcessorFinderTest.php
+++ b/tests/Finder/LinuxyNProcessorFinderTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
 use Fidry\CpuCoreCounter\Finder\LinuxyNProcessorFinder;
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 
 /**
  * @covers \Fidry\CpuCoreCounter\Finder\LinuxyNProcessorFinder
  *
  * @internal
  */
-final class LinuxyNProcessorFinderTest extends PopenBasedFinderTestCase
+final class LinuxyNProcessorFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
         self::assertSame('LinuxyNProcessorFinder', $this->getFinder()->toString());
     }
 
-    protected function getFinder(): PopenBasedFinder
+    protected function getFinder(): ProcOpenBasedFinder
     {
         return new LinuxyNProcessorFinder();
     }

--- a/tests/Finder/NProcessorFinderTest.php
+++ b/tests/Finder/NProcessorFinderTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
 use Fidry\CpuCoreCounter\Finder\NProcessorFinder;
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 
 /**
  * @covers \Fidry\CpuCoreCounter\Finder\NProcessorFinder
  *
  * @internal
  */
-final class NProcessorFinderTest extends PopenBasedFinderTestCase
+final class NProcessorFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
         self::assertSame('NProcessorFinder', $this->getFinder()->toString());
     }
 
-    protected function getFinder(): PopenBasedFinder
+    protected function getFinder(): ProcOpenBasedFinder
     {
         return new NProcessorFinder();
     }

--- a/tests/Finder/ProcOpenBasedFinderTest.php
+++ b/tests/Finder/ProcOpenBasedFinderTest.php
@@ -16,11 +16,11 @@ namespace Fidry\CpuCoreCounter\Test\Finder;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Fidry\CpuCoreCounter\Finder\PopenBasedFinder
+ * @covers \Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder
  *
  * @internal
  */
-final class PopenBasedFinderTest extends TestCase
+final class ProcOpenBasedFinderTest extends TestCase
 {
     /**
      * @dataProvider popenFgetsProvider
@@ -29,7 +29,7 @@ final class PopenBasedFinderTest extends TestCase
         string $nproc,
         ?int $expected
     ): void {
-        $actual = DummyPopenBasedFinder::countCpuCores($nproc);
+        $actual = DummyProcOpenBasedFinder::countCpuCores($nproc);
 
         self::assertSame($expected, $actual);
     }
@@ -82,8 +82,8 @@ EOF
 
     public function test_it_can_describe_itself(): void
     {
-        $finder = new DummyPopenBasedFinder();
+        $finder = new DummyProcOpenBasedFinder();
 
-        self::assertSame('DummyPopenBasedFinder', $finder->toString());
+        self::assertSame('DummyProcOpenBasedFinder', $finder->toString());
     }
 }

--- a/tests/Finder/ProcOpenBasedFinderTestCase.php
+++ b/tests/Finder/ProcOpenBasedFinderTestCase.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 use PHPUnit\Framework\TestCase;
 
-abstract class PopenBasedFinderTestCase extends TestCase
+abstract class ProcOpenBasedFinderTestCase extends TestCase
 {
     /**
      * @dataProvider processResultProvider
@@ -76,5 +76,5 @@ EOF
         ];
     }
 
-    abstract protected function getFinder(): PopenBasedFinder;
+    abstract protected function getFinder(): ProcOpenBasedFinder;
 }

--- a/tests/Finder/WindowsWmicLogicalFinderTest.php
+++ b/tests/Finder/WindowsWmicLogicalFinderTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 use Fidry\CpuCoreCounter\Finder\WindowsWmicLogicalFinder;
 
 /**
@@ -21,14 +21,14 @@ use Fidry\CpuCoreCounter\Finder\WindowsWmicLogicalFinder;
  *
  * @internal
  */
-final class WindowsWmicLogicalFinderTest extends PopenBasedFinderTestCase
+final class WindowsWmicLogicalFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
         self::assertSame('WindowsWmicLogicalFinder', $this->getFinder()->toString());
     }
 
-    protected function getFinder(): PopenBasedFinder
+    protected function getFinder(): ProcOpenBasedFinder
     {
         return new WindowsWmicLogicalFinder();
     }

--- a/tests/Finder/WindowsWmicPhysicalFinderTest.php
+++ b/tests/Finder/WindowsWmicPhysicalFinderTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
-use Fidry\CpuCoreCounter\Finder\PopenBasedFinder;
+use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
 use Fidry\CpuCoreCounter\Finder\WindowsWmicPhysicalFinder;
 
 /**
@@ -21,14 +21,14 @@ use Fidry\CpuCoreCounter\Finder\WindowsWmicPhysicalFinder;
  *
  * @internal
  */
-final class WindowsWmicPhysicalFinderTest extends PopenBasedFinderTestCase
+final class WindowsWmicPhysicalFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
         self::assertSame('WindowsWmicPhysicalFinder', $this->getFinder()->toString());
     }
 
-    protected function getFinder(): PopenBasedFinder
+    protected function getFinder(): ProcOpenBasedFinder
     {
         return new WindowsWmicPhysicalFinder();
     }


### PR DESCRIPTION
This should allow to have more control on the STDERR which on Linux & Windows are just written in the output, polluting it.