### PR TITLE
Extract skipping or not a finder on Windows into a decorator finder

### DIFF
--- a/e2e/expected-output-osx
+++ b/e2e/expected-output-osx
@@ -7,5 +7,7 @@ NProcessorFinder: .
 NProcFinder(all=true): F
 NProcFinder(all=false): F
 NullCpuCoreFinder: F
-WindowsWmicPhysicalFinder: F
-WindowsWmicLogicalFinder: F
+OnlyOnWindowsFinder(DummyCpuCoreFinder(value=1)): F
+SkipOnWindowsFinder(DummyCpuCoreFinder(value=1)): .
+WmicPhysicalFinder: F
+WmicLogicalFinder: F

--- a/e2e/expected-output-ubuntu
+++ b/e2e/expected-output-ubuntu
@@ -7,5 +7,7 @@ NProcessorFinder: F
 NProcFinder(all=true): .
 NProcFinder(all=false): .
 NullCpuCoreFinder: F
-WindowsWmicPhysicalFinder: F
-WindowsWmicLogicalFinder: F
+OnlyOnWindowsFinder(DummyCpuCoreFinder(value=1)): F
+SkipOnWindowsFinder(DummyCpuCoreFinder(value=1)): .
+WmicPhysicalFinder: F
+WmicLogicalFinder: F

--- a/e2e/expected-output-windows
+++ b/e2e/expected-output-windows
@@ -7,5 +7,7 @@ NProcessorFinder: F
 NProcFinder(all=true): F
 NProcFinder(all=false): F
 NullCpuCoreFinder: F
-WindowsWmicPhysicalFinder: F
-WindowsWmicLogicalFinder: F
+OnlyOnWindowsFinder(DummyCpuCoreFinder(value=1)): .
+SkipOnWindowsFinder(DummyCpuCoreFinder(value=1)): F
+WmicPhysicalFinder: F
+WmicLogicalFinder: F

--- a/src/Finder/FinderRegistry.php
+++ b/src/Finder/FinderRegistry.php
@@ -30,8 +30,14 @@ final class FinderRegistry
             new NProcFinder(true),
             new NProcFinder(false),
             new NullCpuCoreFinder(),
-            new WindowsWmicPhysicalFinder(),
-            new WindowsWmicLogicalFinder(),
+            new OnlyOnWindowsFinder(
+                new DummyCpuCoreFinder(1)
+            ),
+            new SkipOnWindowsFinder(
+                new DummyCpuCoreFinder(1)
+            ),
+            new WmicPhysicalFinder(),
+            new WmicLogicalFinder(),
         ];
     }
 
@@ -41,7 +47,7 @@ final class FinderRegistry
     public static function getDefaultLogicalFinders(): array
     {
         return [
-            new WindowsWmicLogicalFinder(),
+            new OnlyOnWindowsFinder(new WmicLogicalFinder()),
             new NProcFinder(),
             new HwLogicalFinder(),
             new LinuxyNProcessorFinder(),
@@ -56,7 +62,7 @@ final class FinderRegistry
     public static function getDefaultPhysicalFinders(): array
     {
         return [
-            new WindowsWmicPhysicalFinder(),
+            new OnlyOnWindowsFinder(new WmicPhysicalFinder()),
             new HwPhysicalFinder(),
         ];
     }

--- a/src/Finder/OnlyOnWindowsFinder.php
+++ b/src/Finder/OnlyOnWindowsFinder.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Finder;
+
+use function defined;
+use function sprintf;
+
+final class OnlyOnWindowsFinder implements CpuCoreFinder
+{
+    /**
+     * @var CpuCoreFinder
+     */
+    private $decoratedFinder;
+
+    public function __construct(CpuCoreFinder $decoratedFinder)
+    {
+        $this->decoratedFinder = $decoratedFinder;
+    }
+
+    public function diagnose(): string
+    {
+        return self::skip()
+            ? 'Non-windows platform detected (PHP_WINDOWS_VERSION_MAJOR is not set).'
+            : $this->decoratedFinder->diagnose();
+    }
+
+    public function find(): ?int
+    {
+        return self::skip()
+            ? null
+            : $this->decoratedFinder->find();
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            'OnlyOnWindowsFinder(%s)',
+            $this->decoratedFinder->toString()
+        );
+    }
+
+    private static function skip(): bool
+    {
+        // Skip if not on Windows. Rely on PHP to detect the platform
+        // rather than reading the platform name or others.
+        return !defined('PHP_WINDOWS_VERSION_MAJOR');
+    }
+}

--- a/src/Finder/SkipOnWindowsFinder.php
+++ b/src/Finder/SkipOnWindowsFinder.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Finder;
+
+use function defined;
+use function sprintf;
+
+final class SkipOnWindowsFinder implements CpuCoreFinder
+{
+    /**
+     * @var CpuCoreFinder
+     */
+    private $decoratedFinder;
+
+    public function __construct(CpuCoreFinder $decoratedFinder)
+    {
+        $this->decoratedFinder = $decoratedFinder;
+    }
+
+    public function diagnose(): string
+    {
+        return self::skip()
+            ? 'Windows platform detected (PHP_WINDOWS_VERSION_MAJOR is set).'
+            : $this->decoratedFinder->diagnose();
+    }
+
+    public function find(): ?int
+    {
+        return self::skip()
+            ? null
+            : $this->decoratedFinder->find();
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            'SkipOnWindowsFinder(%s)',
+            $this->decoratedFinder->toString()
+        );
+    }
+
+    private static function skip(): bool
+    {
+        // Skip if on Windows. Rely on PHP to detect the platform
+        // rather than reading the platform name or others.
+        return defined('PHP_WINDOWS_VERSION_MAJOR');
+    }
+}

--- a/src/Finder/WmicLogicalFinder.php
+++ b/src/Finder/WmicLogicalFinder.php
@@ -13,29 +13,13 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCoreCounter\Finder;
 
-use function defined;
-
 /**
  * Find the number of logical CPU cores for Windows.
  *
  * @see https://github.com/paratestphp/paratest/blob/c163539818fd96308ca8dc60f46088461e366ed4/src/Runners/PHPUnit/Options.php#L912-L916
  */
-final class WindowsWmicLogicalFinder extends ProcOpenBasedFinder
+final class WmicLogicalFinder extends ProcOpenBasedFinder
 {
-    /**
-     * @return positive-int|null
-     */
-    public function find(): ?int
-    {
-        if (!defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            // Skip if not on Windows. Rely on PHP to detect the platform
-            // rather than reading the platform name or others.
-            return null;
-        }
-
-        return parent::find();
-    }
-
     protected function getCommand(): string
     {
         return 'wmic cpu get NumberOfLogicalProcessors';

--- a/src/Finder/WmicPhysicalFinder.php
+++ b/src/Finder/WmicPhysicalFinder.php
@@ -13,29 +13,13 @@ declare(strict_types=1);
 
 namespace Fidry\CpuCoreCounter\Finder;
 
-use function defined;
-
 /**
  * Find the number of physical CPU cores for Windows.
  *
  * @see https://github.com/paratestphp/paratest/blob/c163539818fd96308ca8dc60f46088461e366ed4/src/Runners/PHPUnit/Options.php#L912-L916
  */
-final class WindowsWmicPhysicalFinder extends ProcOpenBasedFinder
+final class WmicPhysicalFinder extends ProcOpenBasedFinder
 {
-    /**
-     * @return positive-int|null
-     */
-    public function find(): ?int
-    {
-        if (!defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            // Skip if not on Windows. Rely on PHP to detect the platform
-            // rather than reading the platform name or others.
-            return null;
-        }
-
-        return parent::find();
-    }
-
     protected function getCommand(): string
     {
         return 'wmic cpu get NumberOfProcessors';

--- a/tests/Finder/FakeFinder.php
+++ b/tests/Finder/FakeFinder.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Test\Finder;
+
+use DomainException;
+use Fidry\CpuCoreCounter\Finder\CpuCoreFinder;
+
+final class FakeFinder implements CpuCoreFinder
+{
+    public function diagnose(): string
+    {
+        throw new DomainException('Not implemented.');
+    }
+
+    public function find(): ?int
+    {
+        throw new DomainException('Not implemented.');
+    }
+
+    public function toString(): string
+    {
+        throw new DomainException('Not implemented.');
+    }
+}

--- a/tests/Finder/OnlyOnWindowsFinderTest.php
+++ b/tests/Finder/OnlyOnWindowsFinderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Test\Finder;
+
+use Fidry\CpuCoreCounter\Finder\DummyCpuCoreFinder;
+use Fidry\CpuCoreCounter\Finder\NullCpuCoreFinder;
+use Fidry\CpuCoreCounter\Finder\OnlyOnWindowsFinder;
+use PHPUnit\Framework\TestCase;
+use function define;
+use function defined;
+
+/**
+ * @covers \Fidry\CpuCoreCounter\Finder\OnlyOnWindowsFinder
+ *
+ * @internal
+ */
+final class OnlyOnWindowsFinderTest extends TestCase
+{
+    public function test_it_can_describe_itself(): void
+    {
+        $finder = new OnlyOnWindowsFinder(new NullCpuCoreFinder());
+
+        self::assertSame('OnlyOnWindowsFinder(NullCpuCoreFinder)', $finder->toString());
+    }
+
+    public function test_it_enriches_the_decorated_finder_diagnosis(): void
+    {
+        $finder = new OnlyOnWindowsFinder(new NullCpuCoreFinder());
+
+        // Sanity check
+        self::assertFalse(defined('PHP_WINDOWS_VERSION_MAJOR'));
+
+        self::assertSame(
+            <<<'EOF'
+Non-windows platform detected (PHP_WINDOWS_VERSION_MAJOR is not set).
+EOF
+            ,
+            $finder->diagnose()
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function test_it_enriches_the_decorated_finder_diagnosis_on_windows(): void
+    {
+        define('PHP_WINDOWS_VERSION_MAJOR', 'some_windows_version');
+        $finder = new OnlyOnWindowsFinder(new NullCpuCoreFinder());
+
+        self::assertSame(
+            <<<'EOF'
+Will return "null".
+EOF
+            ,
+            $finder->diagnose()
+        );
+    }
+
+    public function test_it_skips_its_execution_when_not_on_windows(): void
+    {
+        $finder = new OnlyOnWindowsFinder(new FakeFinder());
+
+        // Sanity check
+        self::assertFalse(defined('PHP_WINDOWS_VERSION_MAJOR'));
+
+        self::assertNull($finder->find());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function test_it_does_not_skip_its_execution_when_not_on_windows(): void
+    {
+        define('PHP_WINDOWS_VERSION_MAJOR', 'some_windows_version');
+        $finder = new OnlyOnWindowsFinder(new DummyCpuCoreFinder(1));
+
+        self::assertSame(1, $finder->find());
+    }
+}

--- a/tests/Finder/SkipOnWindowsFinderTest.php
+++ b/tests/Finder/SkipOnWindowsFinderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Fidry CPUCounter Config package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\CpuCoreCounter\Test\Finder;
+
+use Fidry\CpuCoreCounter\Finder\DummyCpuCoreFinder;
+use Fidry\CpuCoreCounter\Finder\NullCpuCoreFinder;
+use Fidry\CpuCoreCounter\Finder\SkipOnWindowsFinder;
+use PHPUnit\Framework\TestCase;
+use function define;
+use function defined;
+
+/**
+ * @covers \Fidry\CpuCoreCounter\Finder\SkipOnWindowsFinder
+ *
+ * @internal
+ */
+final class SkipOnWindowsFinderTest extends TestCase
+{
+    public function test_it_can_describe_itself(): void
+    {
+        $finder = new SkipOnWindowsFinder(new NullCpuCoreFinder());
+
+        self::assertSame('SkipOnWindowsFinder(NullCpuCoreFinder)', $finder->toString());
+    }
+
+    public function test_it_enriches_the_decorated_finder_diagnosis(): void
+    {
+        $finder = new SkipOnWindowsFinder(new NullCpuCoreFinder());
+
+        // Sanity check
+        self::assertFalse(defined('PHP_WINDOWS_VERSION_MAJOR'));
+
+        self::assertSame(
+            'Will return "null".',
+            $finder->diagnose()
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function test_it_enriches_the_decorated_finder_diagnosis_on_windows(): void
+    {
+        define('PHP_WINDOWS_VERSION_MAJOR', 'some_windows_version');
+        $finder = new SkipOnWindowsFinder(new NullCpuCoreFinder());
+
+        self::assertSame(
+            'Windows platform detected (PHP_WINDOWS_VERSION_MAJOR is set).',
+            $finder->diagnose()
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function test_it_skips_its_execution_when_on_windows(): void
+    {
+        define('PHP_WINDOWS_VERSION_MAJOR', 'some_windows_version');
+        $finder = new SkipOnWindowsFinder(new DummyCpuCoreFinder(1));
+
+        self::assertNull($finder->find());
+    }
+
+    public function test_it_does_not_skip_its_execution_when_not_on_windows(): void
+    {
+        $finder = new SkipOnWindowsFinder(new DummyCpuCoreFinder(1));
+
+        // Sanity check
+        self::assertFalse(defined('PHP_WINDOWS_VERSION_MAJOR'));
+
+        self::assertSame(1, $finder->find());
+    }
+}

--- a/tests/Finder/WmicLogicalFinderTest.php
+++ b/tests/Finder/WmicLogicalFinderTest.php
@@ -14,22 +14,22 @@ declare(strict_types=1);
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
 use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
-use Fidry\CpuCoreCounter\Finder\WindowsWmicLogicalFinder;
+use Fidry\CpuCoreCounter\Finder\WmicLogicalFinder;
 
 /**
- * @covers \Fidry\CpuCoreCounter\Finder\WindowsWmicLogicalFinder
+ * @covers \Fidry\CpuCoreCounter\Finder\WmicLogicalFinder
  *
  * @internal
  */
-final class WindowsWmicLogicalFinderTest extends ProcOpenBasedFinderTestCase
+final class WmicLogicalFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
-        self::assertSame('WindowsWmicLogicalFinder', $this->getFinder()->toString());
+        self::assertSame('WmicLogicalFinder', $this->getFinder()->toString());
     }
 
     protected function getFinder(): ProcOpenBasedFinder
     {
-        return new WindowsWmicLogicalFinder();
+        return new WmicLogicalFinder();
     }
 }

--- a/tests/Finder/WmicPhysicalFinderTest.php
+++ b/tests/Finder/WmicPhysicalFinderTest.php
@@ -14,22 +14,22 @@ declare(strict_types=1);
 namespace Fidry\CpuCoreCounter\Test\Finder;
 
 use Fidry\CpuCoreCounter\Finder\ProcOpenBasedFinder;
-use Fidry\CpuCoreCounter\Finder\WindowsWmicPhysicalFinder;
+use Fidry\CpuCoreCounter\Finder\WmicPhysicalFinder;
 
 /**
- * @covers \Fidry\CpuCoreCounter\Finder\WindowsWmicPhysicalFinder
+ * @covers \Fidry\CpuCoreCounter\Finder\WmicPhysicalFinder
  *
  * @internal
  */
-final class WindowsWmicPhysicalFinderTest extends ProcOpenBasedFinderTestCase
+final class WmicPhysicalFinderTest extends ProcOpenBasedFinderTestCase
 {
     public function test_it_can_describe_itself(): void
     {
-        self::assertSame('WindowsWmicPhysicalFinder', $this->getFinder()->toString());
+        self::assertSame('WmicPhysicalFinder', $this->getFinder()->toString());
     }
 
     protected function getFinder(): ProcOpenBasedFinder
     {
-        return new WindowsWmicPhysicalFinder();
+        return new WmicPhysicalFinder();
     }
 }


### PR DESCRIPTION
This offers more flexibility to both the user and internally for diagnosis purposes.