### PR TITLE
ci: Remove PHP-CS-Fixer config from legacy tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -110,7 +110,7 @@ jobs:
             -   name: "Remove incompatible dev dependencies"
                 run: |
                     composer remove --dev fidry/makefile --no-update --no-install;
-                    composer remove --dev theofidry/php-cs-fixer-config --no-update --no-install;
+                    composer remove --dev fidry/php-cs-fixer-config --no-update --no-install;
                     composer remove --dev webmozarts/strict-phpunit --no-update --no-install;
 
             -   name: "Set up PHP"


### PR DESCRIPTION
This would have helped to avoid some patches on
https://github.com/theofidry/php-cs-fixer-config but now that it is done at the very least it will allow to update the project without problems in the future.