### PR TITLE
fix: Do not use `--all` for nproc by default

### DIFF
--- a/src/Finder/NProcFinder.php
+++ b/src/Finder/NProcFinder.php
@@ -30,10 +30,13 @@ final class NProcFinder extends ProcOpenBasedFinder
     private $all;
 
     /**
-     * @param bool $all If disabled will give the number of cores available for the current process only.
+     * @param bool $all If disabled will give the number of cores available for the current process
+     *                  only. This is disabled by default as it is known to be "buggy" on virtual
+     *                  environments as the virtualization tool, e.g. VMWare, might over-commit
+     *                  resources by default.
      */
     public function __construct(
-        bool $all = true,
+        bool $all = false,
         ?ProcessExecutor $executor = null
     ) {
         parent::__construct($executor);

--- a/tests/Finder/NProcFinderTest.php
+++ b/tests/Finder/NProcFinderTest.php
@@ -53,26 +53,26 @@ final class NProcFinderTest extends TestCase
 
     public static function finderProvider(): iterable
     {
-        yield [
-            new NProcFinder(true),
-            sprintf(
-                '%s(all=true)',
-                FinderShortClassName::get(new NProcFinder())
-            )
-        ];
-
-        yield [
+        yield 'default constructor parameters' => [
             new NProcFinder(),
             sprintf(
-                '%s(all=true)',
+                '%s(all=false)',
                 FinderShortClassName::get(new NProcFinder())
             )
         ];
 
-        yield [
+        yield 'without all' => [
             new NProcFinder(false),
             sprintf(
                 '%s(all=false)',
+                FinderShortClassName::get(new NProcFinder())
+            )
+        ];
+
+        yield 'with all' => [
+            new NProcFinder(true),
+            sprintf(
+                '%s(all=true)',
                 FinderShortClassName::get(new NProcFinder())
             )
         ];


### PR DESCRIPTION
See
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8129#issuecomment-2255284362.