### PR TITLE
feat: Do not reserve a CPU core by default

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -56,8 +56,6 @@ final class CpuCoreCounter
      *                                        of the system in the past minute. Should be a positive
      *                                        float.
      *
-     * @return positive-int
-     *
      * @see https://php.net/manual/en/function.sys-getloadavg.php
      */
     public function getAvailableForParallelisation(

--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -41,7 +41,11 @@ final class CpuCoreCounter
     }
 
     /**
-     * @param positive-int $reservedCpus
+     * @param positive-int|0 $reservedCpus Number of CPUs to reserve. This is useful when you want
+     *                                     to reserve some CPUs for other processes. If the main
+     *                                     process is going to be busy still, you may want to set
+     *                                     this value to 1.
+     *
      * @param positive-int $limit
      * @param float        $loadLimitPerCore  Limits the number of CPUs based on the system load
      *                                        average per core in a range of [0., 1.].
@@ -55,7 +59,7 @@ final class CpuCoreCounter
      * @see https://php.net/manual/en/function.sys-getloadavg.php
      */
     public function getAvailableForParallelisation(
-        int $reservedCpus = 1,
+        int $reservedCpus = 0,
         ?int $limit = null,
         ?float $loadLimitPerCore = .9,
         ?float $systemLoadAverage = null

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -251,7 +251,7 @@ final class CpuCoreCounterTest extends TestCase
             return [
                 [$finder],
                 ['KUBERNETES_CPU_LIMIT' => 8],
-                null,
+                1,
                 null,
                 null,
                 null,
@@ -265,7 +265,7 @@ final class CpuCoreCounterTest extends TestCase
             return [
                 [$finder],
                 ['KUBERNETES_CPU_LIMIT' => 5],
-                null,
+                1,
                 null,
                 null,
                 null,
@@ -279,7 +279,7 @@ final class CpuCoreCounterTest extends TestCase
             return [
                 [$finder],
                 ['KUBERNETES_CPU_LIMIT' => 4],
-                null,
+                1,
                 null,
                 null,
                 null,
@@ -301,7 +301,7 @@ final class CpuCoreCounterTest extends TestCase
             ];
         })();
 
-        yield 'CPU count found' => (static function () {
+        yield 'CPU count found: by default it reserves no CPU' => (static function () {
             $finder = new DummyCpuCoreFinder(5);
 
             return [
@@ -311,7 +311,7 @@ final class CpuCoreCounterTest extends TestCase
                 null,
                 null,
                 null,
-                4,
+                5,
             ];
         })();
 


### PR DESCRIPTION
In PHP most of the time if multiple processes are launched, the main process will become idle hence it is not necessary to reserve a CPU core for it.