### PR TITLE
fix: Correct the reserved CPU core phpdoc

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -43,14 +43,14 @@ final class CpuCoreCounter
     }
 
     /**
-     * @param positive-int $reservedCpus
-     * @param positive-int $limit
-     * @param float        $loadLimitPerCore  Limits the number of CPUs based on the system load
-     *                                        average per core in a range of [0., 1.].
-     * @param float        $systemLoadAverage The system load average. If not provided, it will be
-     *                                        retrieved using `sys_getloadavg()` to check the load
-     *                                        of the system in the past minute. Should be a positive
-     *                                        float.
+     * @param positive-int|0 $reservedCpus
+     * @param positive-int   $limit
+     * @param float          $loadLimitPerCore  Limits the number of CPUs based on the system load
+     *                                          average per core in a range of [0., 1.].
+     * @param float          $systemLoadAverage The system load average. If not provided, it will be
+     *                                          retrieved using `sys_getloadavg()` to check the load
+     *                                          of the system in the past minute. Should be a positive
+     *                                          float.
      *
      * @see https://php.net/manual/en/function.sys-getloadavg.php
      */

--- a/src/ParallelisationResult.php
+++ b/src/ParallelisationResult.php
@@ -19,7 +19,7 @@ namespace Fidry\CpuCoreCounter;
 final class ParallelisationResult
 {
     /**
-     * @var positive-int
+     * @var positive-int|0
      */
     public $passedReservedCpus;
 
@@ -59,7 +59,7 @@ final class ParallelisationResult
     public $availableCpus;
 
     /**
-     * @param positive-int      $passedReservedCpus
+     * @param positive-int|0    $passedReservedCpus
      * @param positive-int|null $passedLimit
      * @param positive-int      $totalCoresCount
      * @param positive-int      $availableCpus


### PR DESCRIPTION
The value `0` is valid and allowed.