### PR TITLE
feat: Rework the load limit

### DIFF
--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -47,6 +47,7 @@ final class CpuCoreCounter
      *                                          to reserve some CPUs for other processes. If the main
      *                                          process is going to be busy still, you may want to set
      *                                          this value to 1.
+     * @param positive-int   $limit
      * @param float|null     $loadLimit         Element of [0., 1.]. Percentage representing the
      *                                          amount of cores that should be used among the available
      *                                          resources. For instance, if set to 0.7, it will use 70%
@@ -58,7 +59,7 @@ final class CpuCoreCounter
      *                                          previous example, it will return 5 cores. How busy is
      *                                          the system is determined by the system load average
      *                                          (see $systemLoadAverage).
-     * @param float          $systemLoadAverage The system load average. If not provided, it will be
+     * @param float|null     $systemLoadAverage The system load average. If not provided, it will be
      *                                          retrieved using `sys_getloadavg()` to check the load
      *                                          of the system in the past minute. Should be a positive
      *                                          float.

--- a/src/CpuCoreCounter.php
+++ b/src/CpuCoreCounter.php
@@ -43,6 +43,7 @@ final class CpuCoreCounter
     }
 
     /**
+<<<<<<< Updated upstream
      * @param positive-int|0 $reservedCpus Number of CPUs to reserve. This is useful when you want
      *                                     to reserve some CPUs for other processes. If the main
      *                                     process is going to be busy still, you may want to set
@@ -55,16 +56,27 @@ final class CpuCoreCounter
      *                                        retrieved using `sys_getloadavg()` to check the load
      *                                        of the system in the past minute. Should be a positive
      *                                        float.
+=======
+     * @param positive-int|0 $reservedCpus
+     * @param positive-int   $limit
+     * @param float          $loadLimit         Element of [0., 1.]. Limits the number of CPUs based on the system load
+     *                                          average. Set it to null or 1. to disable the check, it otherwise
+     *                                          will adjust the number of CPUs based on the system load average. For example if 3 cores out of 10 are busy and the load limit is set to 50%, only 2 cores will be available for parallelisation.
+     * @param float          $systemLoadAverage The system load average. If not provided, it will be
+     *                                          retrieved using `sys_getloadavg()` to check the load
+     *                                          of the system in the past minute. Should be a positive
+     *                                          float.
+>>>>>>> Stashed changes
      *
      * @see https://php.net/manual/en/function.sys-getloadavg.php
      */
     public function getAvailableForParallelisation(
         int $reservedCpus = 0,
         ?int $limit = null,
-        ?float $loadLimitPerCore = .9,
+        ?float $loadLimit = .9,
         ?float $systemLoadAverage = null
     ): ParallelisationResult {
-        self::checkLoadLimitPerCore($loadLimitPerCore);
+        self::checkLoadLimitPerCore($loadLimit);
         self::checkSystemLoadAverage($systemLoadAverage);
 
         $correctedLimit = null === $limit
@@ -81,7 +93,7 @@ final class CpuCoreCounter
         $systemLoadAveragePerCore = $correctedSystemLoadAverage / $availableCpus;
 
         // Adjust available CPUs based on current load
-        if (null !== $loadLimitPerCore && $systemLoadAveragePerCore > $loadLimitPerCore) {
+        if (null !== $loadLimit && $systemLoadAveragePerCore > $loadLimit) {
             $adjustedCpus = max(
                 1,
                 (1 - $systemLoadAveragePerCore) * $availableCpus
@@ -96,7 +108,7 @@ final class CpuCoreCounter
         return new ParallelisationResult(
             $reservedCpus,
             $limit,
-            $loadLimitPerCore,
+            $loadLimit,
             $systemLoadAverage,
             $correctedLimit,
             $correctedSystemLoadAverage,

--- a/src/ParallelisationResult.php
+++ b/src/ParallelisationResult.php
@@ -70,7 +70,7 @@ final class ParallelisationResult
         ?float $passedLoadLimitPerCore,
         ?float $passedSystemLoadAverage,
         ?int $correctedLimit,
-        float $correctedSystemLoadAverage,
+        ?float $correctedSystemLoadAverage,
         int $totalCoresCount,
         int $availableCpus
     ) {

--- a/src/ParallelisationResult.php
+++ b/src/ParallelisationResult.php
@@ -31,7 +31,7 @@ final class ParallelisationResult
     /**
      * @var float|null
      */
-    public $passedLoadLimitPerCore;
+    public $passedLoadLimit;
 
     /**
      * @var float|null
@@ -44,7 +44,7 @@ final class ParallelisationResult
     public $correctedLimit;
 
     /**
-     * @var float
+     * @var float|null
      */
     public $correctedSystemLoadAverage;
 
@@ -67,7 +67,7 @@ final class ParallelisationResult
     public function __construct(
         int $passedReservedCpus,
         ?int $passedLimit,
-        ?float $passedLoadLimitPerCore,
+        ?float $passedLoadLimit,
         ?float $passedSystemLoadAverage,
         ?int $correctedLimit,
         ?float $correctedSystemLoadAverage,
@@ -76,7 +76,7 @@ final class ParallelisationResult
     ) {
         $this->passedReservedCpus = $passedReservedCpus;
         $this->passedLimit = $passedLimit;
-        $this->passedLoadLimitPerCore = $passedLoadLimitPerCore;
+        $this->passedLoadLimit = $passedLoadLimit;
         $this->passedSystemLoadAverage = $passedSystemLoadAverage;
         $this->correctedLimit = $correctedLimit;
         $this->correctedSystemLoadAverage = $correctedSystemLoadAverage;

--- a/tests/AvailableCpuCoresScenario.php
+++ b/tests/AvailableCpuCoresScenario.php
@@ -49,7 +49,7 @@ final class AvailableCpuCoresScenario
         array $environmentVariables,
         int $reservedCpus,
         ?int $limit,
-        ?float $loadLimitPerCore,
+        ?float $loadLimit,
         ?float $systemLoadAverage,
         int $expected
     ) {
@@ -57,7 +57,7 @@ final class AvailableCpuCoresScenario
         $this->environmentVariables = $environmentVariables;
         $this->reservedCpus = $reservedCpus;
         $this->limit = $limit;
-        $this->loadLimitPerCore = $loadLimitPerCore;
+        $this->loadLimitPerCore = $loadLimit;
         $this->systemLoadAverage = $systemLoadAverage;
         $this->expected = $expected;
     }
@@ -76,7 +76,7 @@ final class AvailableCpuCoresScenario
         array $environmentVariables,
         ?int $reservedCpus,
         ?int $limit,
-        ?float $loadLimitPerCore,
+        ?float $loadLimit,
         ?float $systemLoadAverage,
         int $expected
     ): array {
@@ -90,7 +90,7 @@ final class AvailableCpuCoresScenario
                 $environmentVariables,
                 $reservedCpus ?? 0,
                 $limit,
-                $loadLimitPerCore,
+                $loadLimit,
                 $systemLoadAverage ?? 0.,
                 $expected
             ),

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -299,14 +299,24 @@ final class CpuCoreCounterTest extends TestCase
             1
         );
 
-        yield 'CPU count found, over half the cores are used' => AvailableCpuCoresScenario::create(
+        yield 'CPU count found, over half the cores are used and no limit is set' => AvailableCpuCoresScenario::create(
             11,
             [],
             1,
             null,
-            .9,
+            null,
             6.,
             10
+        );
+
+        yield 'CPU count found, over half the cores are used and a limit is set' => AvailableCpuCoresScenario::create(
+            11,
+            [],
+            1,
+            null,
+            1.,
+            6.,
+            4
         );
 
         yield 'CPU count found, the CPUs are overloaded' => AvailableCpuCoresScenario::create(
@@ -319,24 +329,24 @@ final class CpuCoreCounterTest extends TestCase
             1
         );
 
-        yield 'CPU count found, the CPUs are being the limit set, but there is several CPUs available still' => AvailableCpuCoresScenario::create(
+        yield 'CPU count found, the load limit is set, but there is several CPUs available still' => AvailableCpuCoresScenario::create(
             11,
             [],
             1,
             null,
             .5,
             6.,
-            4
+            2
         );
 
-        yield 'CPU count found, the CPUs are at the limit of being overloaded' => AvailableCpuCoresScenario::create(
+        yield 'CPU count found, the CPUs are at completely overloaded' => AvailableCpuCoresScenario::create(
             11,
             [],
             1,
             null,
-            .9,
-            9.,
-            10
+            .5,
+            11.,
+            1
         );
 
         yield 'CPU count found, the CPUs are overloaded but no load limit per CPU' => AvailableCpuCoresScenario::create(

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -307,10 +307,10 @@ final class CpuCoreCounterTest extends TestCase
             return [
                 [$finder],
                 [],
+                0,
                 null,
                 null,
-                null,
-                null,
+                .0,
                 5,
             ];
         })();
@@ -367,7 +367,7 @@ final class CpuCoreCounterTest extends TestCase
                 null,
                 .9,
                 6.,
-                10,
+                3,
             ];
         })();
 
@@ -386,7 +386,7 @@ final class CpuCoreCounterTest extends TestCase
         })();
 
         yield 'CPU count found, the CPUs are being the limit set, but there is several CPUs available still' => (static function () {
-            $finder = new DummyCpuCoreFinder(11);
+            $finder = new DummyCpuCoreFinder(10);
 
             return [
                 [$finder],
@@ -424,6 +424,20 @@ final class CpuCoreCounterTest extends TestCase
                 null,
                 9.5,
                 10,
+            ];
+        })();
+
+        yield 'load limit doc example' => (static function () {
+            $finder = new DummyCpuCoreFinder(10);
+
+            return [
+                [$finder],
+                [],
+                0,
+                null,
+                .5,
+                3,
+                2,
             ];
         })();
     }


### PR DESCRIPTION
- Make the load limit about the _available_ resources, i.e. if there is 11 cores, 1 is reserved and 5 are busy, it will limit it based on `11-1-5=5` cores. So `1.` means 100% of 5 cores, `.5` 50% of 5 cores.
- Do not have a limit by default