### PR TITLE
Support `KUBERNETES_CPU_LIMIT` using millicores

### DIFF
--- a/src/Finder/EnvVariableFinder.php
+++ b/src/Finder/EnvVariableFinder.php
@@ -44,6 +44,12 @@ final class EnvVariableFinder implements CpuCoreFinder
     {
         $value = getenv($this->environmentVariableName);
 
+        if (is_string($value) && 1 === preg_match('/^(\d+)m$/', $value, $matches)) {
+            $millicores = (int) $matches[1];
+
+            return (int) floor($millicores / 1000);
+        }
+
         return self::isPositiveInteger($value)
             ? (int) $value
             : null;

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -239,6 +239,36 @@ final class CpuCoreCounterTest extends TestCase
             4
         );
 
+        yield 'CPU count found: Kubernetes limit set using millicores' => AvailableCpuCoresScenario::create(
+            5,
+            ['KUBERNETES_CPU_LIMIT' => '2500m'],
+            1,
+            null,
+            null,
+            null,
+            2
+        );
+
+        yield 'CPU count not found: Kubernetes limit set using millicores with trailing characters' => AvailableCpuCoresScenario::create(
+            5,
+            ['KUBERNETES_CPU_LIMIT' => '2500mA'],
+            1,
+            null,
+            null,
+            null,
+            4
+        );
+
+        yield 'CPU count not found: Kubernetes limit set using millicores with leading characters' => AvailableCpuCoresScenario::create(
+            5,
+            ['KUBERNETES_CPU_LIMIT' => 'A2500m'],
+            1,
+            null,
+            null,
+            null,
+            4
+        );
+
         yield 'CPU count found: kubernetes limit set and equal to the count found after reserved CPUs' => AvailableCpuCoresScenario::create(
             5,
             ['KUBERNETES_CPU_LIMIT' => 4],


### PR DESCRIPTION
`KUBERNETES_CPU_LIMIT` can also be defined in the format of `1000m` meaning 1000 millicores which is equal to 1 CPU core.

The logic for reading this environment variable assumes that will always be a positive integer so this adds support for millicores too