### PR TITLE
Support `KUBERNETES_CPU_LIMIT` using millicores

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -47,7 +47,9 @@
         "Continue_": false,
         "DecrementInteger": {
             "ignore": [
-                "Fidry\\CpuCoreCounter\\CpuCoreCounter::getAvailableForParallelisation"
+                "Fidry\\CpuCoreCounter\\CpuCoreCounter::getAvailableForParallelisation",
+                // False-positive: in this case there is no distinction between (int) "1000m" and (int) "1000"
+                "Fidry\\CpuCoreCounter\\Finder\\EnvVariableFinder::find"
             ]
         },
         "FunctionCallRemoval": {
@@ -74,12 +76,6 @@
             ]
         },
         "PublicVisibility": false,
-        "ReturnRemoval": {
-            "ignore": [
-                // This is a perf improvement
-                "Fidry\\CpuCoreCounter\\CpuCoreCounter::checkLoadLimit"
-            ]
-        },
         "TrueValue": {
             "ignore": [
                 // This is a case where the value does not matter.

--- a/infection.json5
+++ b/infection.json5
@@ -76,6 +76,12 @@
             ]
         },
         "PublicVisibility": false,
+        "ReturnRemoval": {
+            "ignore": [
+                // This is a perf improvement
+                "Fidry\\CpuCoreCounter\\CpuCoreCounter::checkLoadLimit"
+            ]
+        },
         "TrueValue": {
             "ignore": [
                 // This is a case where the value does not matter.

--- a/src/Finder/EnvVariableFinder.php
+++ b/src/Finder/EnvVariableFinder.php
@@ -45,9 +45,8 @@ final class EnvVariableFinder implements CpuCoreFinder
         $value = getenv($this->environmentVariableName);
 
         if (is_string($value) && 1 === preg_match('/^(\d+)m$/', $value, $matches)) {
-            $millicores = (int) $matches[1];
-
-            return (int) floor($millicores / 1000);
+            $millicores = $matches[1];
+            $value = (string) floor($millicores / 1000);
         }
 
         return self::isPositiveInteger($value)

--- a/src/Finder/EnvVariableFinder.php
+++ b/src/Finder/EnvVariableFinder.php
@@ -44,6 +44,12 @@ final class EnvVariableFinder implements CpuCoreFinder
     {
         $value = getenv($this->environmentVariableName);
 
+        if (is_string($value) && 1 === preg_match('/^(\d+)m$/', $value, $matches)) {
+            $millicores = (int) $matches[1];
+
+            return (int) floor($millicores / 1000);
+        }
+
         return self::isPositiveInteger($value)
             ? (int) $value
             : null;

--- a/tests/CpuCoreCounterTest.php
+++ b/tests/CpuCoreCounterTest.php
@@ -239,6 +239,36 @@ final class CpuCoreCounterTest extends TestCase
             4
         );
 
+        yield 'CPU count found: Kubernetes limit set using millicores' => AvailableCpuCoresScenario::create(
+            5,
+            ['KUBERNETES_CPU_LIMIT' => '2500m'],
+            1,
+            null,
+            null,
+            null,
+            2
+        );
+
+        yield 'CPU count not found: Kubernetes limit set using millicores with trailing characters' => AvailableCpuCoresScenario::create(
+            5,
+            ['KUBERNETES_CPU_LIMIT' => '2500mA'],
+            1,
+            null,
+            null,
+            null,
+            4
+        );
+
+        yield 'CPU count not found: Kubernetes limit set using millicores with leading characters' => AvailableCpuCoresScenario::create(
+            5,
+            ['KUBERNETES_CPU_LIMIT' => 'A2500m'],
+            1,
+            null,
+            null,
+            null,
+            4
+        );
+
         yield 'CPU count found: kubernetes limit set and equal to the count found after reserved CPUs' => AvailableCpuCoresScenario::create(
             5,
             ['KUBERNETES_CPU_LIMIT' => 4],

--- a/tests/Finder/EnvVariableFinderTest.php
+++ b/tests/Finder/EnvVariableFinderTest.php
@@ -96,5 +96,30 @@ final class EnvVariableFinderTest extends TestCase
             '"something 18"',
             null,
         ];
+
+        yield 'Kubernetes limit set using millicores' => [
+            '3000m',
+            3,
+        ];
+
+        yield 'Kubernetes limit set using millicores with trailing characters' => [
+            '3000mA',
+            null,
+        ];
+
+        yield 'Kubernetes limit set using millicores with leading characters' => [
+            'A3000m',
+            null,
+        ];
+
+        yield 'millicores with non integer value' => [
+            '30.50m',
+            null,
+        ];
+
+        yield 'Kubernetes limit rounded' => [
+            '2500m',
+            2,
+        ];
     }
 }


### PR DESCRIPTION
Updated #156.

`KUBERNETES_CPU_LIMIT` can also be defined in the format
of `1000m` meaning 1000 millicores which is equal to 1 CPU core.