### PR TITLE
test: Fix the tests slowness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "fidry/makefile": "^0.2.0 || ^1.0",
+        "fidry/makefile": "^0.2.0 || ^1.1.1",
         "fidry/php-cs-fixer-config": "^1.1.2",
         "phpstan/extension-installer": "^1.2.0",
         "phpstan/phpstan": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "fidry/makefile": "^0.2.0",
+        "fidry/makefile": "^0.2.0 || ^1.0",
         "fidry/php-cs-fixer-config": "^1.1.2",
         "phpstan/extension-installer": "^1.2.0",
         "phpstan/phpstan": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+        "symfony/polyfill-mbstring": "^1.33",
         "webmozarts/strict-phpunit": "^7.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "fidry/makefile": "^0.2.0 || ^1.1.1",
+        "fidry/makefile": "^0.2.0 || ^1.1.2",
         "fidry/php-cs-fixer-config": "^1.1.2",
         "phpstan/extension-installer": "^1.2.0",
         "phpstan/phpstan": "^2.0",


### PR DESCRIPTION
This was caused by some deprecations due to not being able to update `fidry/makefile`.